### PR TITLE
Metadata computation in new planner structure.

### DIFF
--- a/d2/runtime/shard_info.py
+++ b/d2/runtime/shard_info.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import torch
+
+from d2.runtime.inplace_metadata import (compute_attn_layout_seqlens,
+                                         compute_metadata, compute_metadata_kv)
+
+
+@dataclass
+class ShardInfo:
+    """
+    Metadata of a single shard of a sequence.
+
+    Attributes:
+        rid: The Rank ID where the MLP (Multi-Layer Perceptron) computation for this shard is performed.
+        dispatch_rid: The Rank ID where the Attention computation for this shard is performed.
+        logical_sid: The logical order ID of this shard in the original complete sequence (starting from 0).
+        shard_len: The length of this shard, usually referring to the number of tokens.
+    """
+    rid: int
+    dispatch_rid: int
+    logical_sid: int
+    shard_len: int
+
+
+
+def handle_planner_metadata(
+    world_size: int,
+    sequence_plans: List[List[ShardInfo]]
+) -> Tuple[torch.Tensor, ...]:
+    """
+    Args:
+        world_size: Total number of ranks.
+        sequence_plans: List containing all sequence shard information.
+
+    Returns:
+        A tuple containing all computed metadata tensors.
+    """
+    if not sequence_plans or not any(sequence_plans) or world_size <= 0:
+        raise ValueError("Invalid input! Sequence_plans cannot be None. world_size need bigger than 0.")
+
+    all_shards_with_seq_id = []
+    for seq_idx, sequence in enumerate(sequence_plans):
+        for shard in sequence:
+            all_shards_with_seq_id.append((seq_idx, shard))
+
+    # Sort in a globally deterministic order: first by sequence_id, then by logical_sid
+    all_shards_with_seq_id.sort(key=lambda item: (item[0], item[1].logical_sid))
+
+    rank_shard_counters = torch.zeros(world_size, dtype=torch.int64)
+
+    # hash table, map shard to rank_level_local_sid
+    # key: (seq_idx, logical_sid), value: rank_level_local_sid.
+    shard_to_rank_local_sid = {}
+    for seq_idx, shard in all_shards_with_seq_id:
+        rank_id = shard.rid
+        rank_level_local_sid = int(rank_shard_counters[rank_id])
+        shard_to_rank_local_sid[(seq_idx, shard.logical_sid)] = rank_level_local_sid
+        rank_shard_counters[rank_id] += 1
+
+    mlp_num_shards = rank_shard_counters
+    max_shards_per_rank = int(mlp_num_shards.max())
+
+    max_shards_per_seq = max(len(seq) for seq in sequence_plans)
+
+    mlp_q_dispatch = torch.ones((world_size, max_shards_per_rank), dtype=torch.int64) * -1
+    cp_seq_lens = torch.zeros((world_size, max_shards_per_rank), dtype=torch.int64)
+    kv_context_size = torch.zeros((world_size, max_shards_per_rank), dtype=torch.int64)
+    q_to_num_kv_seq = torch.ones((world_size, max_shards_per_rank), dtype=torch.int64) * -1
+    kv_to_q_mapping = torch.ones((world_size, max_shards_per_rank, max_shards_per_seq, 2), dtype=torch.int64) * -1
+    kv_to_q_rank = torch.ones((world_size, max_shards_per_rank, max_shards_per_seq), dtype=torch.int64) * -1
+
+    for seq_idx, original_sequence in enumerate(sequence_plans):
+        sequence = sorted(original_sequence, key=lambda s: s.logical_sid)
+        sequence_cumsum = [0] + [s.shard_len for s in sequence]
+        sequence_cumsum = torch.tensor(sequence_cumsum, dtype=torch.int64).cumsum(dim=0)
+
+        for logical_sid, shard_info in enumerate(sequence):
+            # mlp rank of current shard
+            p_rank = shard_info.rid
+            # rank index of current shard
+            p_local_sid = shard_to_rank_local_sid[(seq_idx, logical_sid)]
+
+            mlp_q_dispatch[p_rank, p_local_sid] = shard_info.dispatch_rid
+            cp_seq_lens[p_rank, p_local_sid] = shard_info.shard_len
+            q_to_num_kv_seq[p_rank, p_local_sid] = logical_sid + 1
+            kv_context_size[p_rank, p_local_sid] = sequence_cumsum[logical_sid]
+
+            # loop all related Q Shards of current KV Shard.
+            for q_idx, q_logical_sid in enumerate(range(logical_sid, len(sequence))):
+                dest_q_shard_info = sequence[q_logical_sid]
+                dest_q_computed_sid = shard_to_rank_local_sid[(seq_idx, q_logical_sid)]
+
+                # kv_to_q_mapping: record the (rid, sid) of the target Q
+                kv_to_q_mapping[p_rank, p_local_sid, q_idx, 0] = dest_q_shard_info.rid
+                kv_to_q_mapping[p_rank, p_local_sid, q_idx, 1] = dest_q_computed_sid
+
+                # kv_to_q_rank: record the index of current KV of the target Q
+                kv_to_q_rank[p_rank, p_local_sid, q_idx] = logical_sid
+
+    q_to_num_kv_tokens = kv_context_size + cp_seq_lens
+
+    return (
+        mlp_num_shards,
+        mlp_q_dispatch,
+        cp_seq_lens,
+        kv_to_q_mapping,
+        kv_to_q_rank,
+        kv_context_size,
+        q_to_num_kv_seq,
+        q_to_num_kv_tokens,
+    )
+
+def plan_to_metadata(
+    world_size: int,
+    sequence_plans: List[List[ShardInfo]],
+    return_intermediate: bool = False
+):
+    (
+        mlp_num_seqs,
+        mlp_q_dispatch,
+        mlp_seq_lens,
+        kv_to_q_mapping,
+        kv_to_q_rank,
+        kv_context_size,
+        q_to_num_kv_seq,
+        q_to_num_kv_tokens,
+    ) = handle_planner_metadata(world_size, sequence_plans)
+
+    # TODO(pb): Use this e2d function after fixed shape error.
+    # final_metadata = compute_e2e_metadata(
+    #     mlp_seq_len=mlp_seq_lens,
+    #     mlp_num_seqs=mlp_num_seqs,
+    #     mlp_q_dispatch=mlp_q_dispatch,
+    #     kv_to_q_mapping=kv_to_q_mapping,
+    #     kv_to_q_rank=kv_to_q_rank,
+    #     kv_context_size=kv_context_size,
+    #     q_to_num_kv_seq=q_to_num_kv_seq,
+    #     q_to_num_kv_token=q_to_num_kv_tokens,
+    #     return_intermediate=return_intermediate
+    # )
+    
+    fwd_metadata_q, rev_metadata_q, q_intermediates = compute_metadata(
+        mlp_seq_lens, mlp_q_dispatch, return_intermediate=True
+    )
+    # reshape 
+    max_num_local_seqs = mlp_q_dispatch.shape[1]
+    _, q_seq_to_dst, num_received_seqs_q = q_intermediates
+
+    # TODO(pb): Fix this in compute_metadata. Shape problem of q_seq_to_dst.
+    q_seq_to_dst = q_seq_to_dst.squeeze(2)
+
+    fwd_metadata_kv, rev_metadata_kv, kv_intermediates = compute_metadata_kv(
+        kv_to_q_mapping, kv_to_q_rank, kv_context_size,
+        q_to_num_kv_seq, q_to_num_kv_tokens, mlp_seq_lens, mlp_num_seqs,
+        mlp_q_dispatch, q_seq_to_dst, max_num_local_seqs,
+        return_intermediate=True
+    )
+
+    (
+        cu_seqlens_q, cu_seqlens_kv, max_seqlen_q, max_seqlen_kv,
+        num_local_seqs_recv
+    ) = compute_attn_layout_seqlens(
+        mlp_seq_lens, q_to_num_kv_tokens, mlp_q_dispatch, shard_to_tuple=True
+    )
+    fa_params = (cu_seqlens_q, cu_seqlens_kv, max_seqlen_q, max_seqlen_kv)
+
+    ret = fwd_metadata_q, rev_metadata_q, fwd_metadata_kv, rev_metadata_kv, fa_params
+    if return_intermediate:
+        ret += (q_intermediates + kv_intermediates,)
+    return ret
+

--- a/tests/test_comm_shard_info.py
+++ b/tests/test_comm_shard_info.py
@@ -1,0 +1,212 @@
+"""Test whether forward and backward metadata generation works correctly."""
+
+import random
+from typing import List
+
+import rich
+import torch
+from test_util import (create_qkv_dispatch, create_qkv_dispatch_2cp,
+                       gen_seq_lens, orchestrate_simulate)
+
+from d2.runtime.inplace_metadata import Metadata, compute_metadata
+from d2.runtime.shard_info import ShardInfo, plan_to_metadata
+
+
+def test_query_dispatch(args):
+    rich.print("🟢 Testing query dispatch")
+
+    torch.manual_seed(args.seed)
+    world_size = args.world_size
+    num_seqs = args.num_seqs
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    hidden_size = args.hidden_size
+    total_seq_len = args.num_tokens
+    seq_len = gen_seq_lens(world_size, num_seqs, total_seq_len).long().to(device)
+    global_dispatch = torch.randint(0, world_size, (world_size, num_seqs),
+                                    device=device)
+
+
+    tensor = torch.rand((world_size, total_seq_len, hidden_size), device=device) + 1    # + 1 to avoid zeros
+    fwd_metadata, rev_metadata = compute_metadata(seq_len, global_dispatch)
+
+    # forward
+    max_recv_tokens = fwd_metadata.num_recv_tokens.max()
+    output_tensor = torch.zeros((world_size, max_recv_tokens, hidden_size),
+                                device=device, dtype=tensor.dtype)
+    output_tensor = orchestrate_simulate(tensor, output_tensor, fwd_metadata)
+
+    # reverse
+    rev_metadata.num_recv_tokens.max()
+    rev_tensor = torch.zeros((world_size, total_seq_len, hidden_size),
+                             device=device, dtype=output_tensor.dtype)
+    rev_tensor = orchestrate_simulate(output_tensor, rev_tensor, rev_metadata)
+    rev_tensor = rev_tensor.reshape(world_size, total_seq_len, hidden_size)
+    torch.testing.assert_close(tensor, rev_tensor)
+    rich.print("🟢 Test query dispatch passed")
+
+
+def test_qkv_dispatch(args):
+    world_size = args.world_size
+    num_seqs = args.num_seqs
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    hidden_size = args.hidden_size
+    total_seq_len = args.num_tokens
+    #max_cp_degree: int = args.max_seq_shard
+    
+    torch.manual_seed(args.seed)
+
+    rich.print("⚪ Testing qkv dispatch")
+
+    (fwd_q_metadata, rev_q_metadata, fwd_k_metadata, rev_k_metadata, _), sequence_plans = test_plan_to_metadata(args)
+    max_cp_degree:int = max(len(s) for s in sequence_plans)
+    rich.print(f"max_cp_degree: {max_cp_degree}")
+    
+    # Test that Query is correctly sent.
+    tensor = torch.rand((world_size, total_seq_len, hidden_size), device=device) + 1    # + 1 to avoid zeros
+    # forward
+    max_recv_tokens = fwd_q_metadata.num_recv_tokens.max()
+    output_tensor = torch.zeros((world_size, max_recv_tokens, hidden_size),
+                                device=device, dtype=tensor.dtype)
+    output_tensor = orchestrate_simulate(tensor, output_tensor, fwd_q_metadata)
+
+    # reverse
+    rev_q_metadata.num_recv_tokens.max()
+    rev_tensor = torch.zeros((world_size, total_seq_len, hidden_size),
+                             device=device, dtype=output_tensor.dtype)
+    rev_tensor = orchestrate_simulate(output_tensor, rev_tensor, rev_q_metadata)
+    rev_tensor = rev_tensor.reshape(world_size, total_seq_len, hidden_size)
+    torch.testing.assert_close(tensor, rev_tensor)
+
+    # Test that key-value is correctly sent.
+    tensor = torch.rand((world_size, total_seq_len, hidden_size), device=device) + 1
+    max_recv_tokens_kv = fwd_k_metadata.num_recv_tokens.max()
+    output_tensor = torch.zeros((world_size, max_recv_tokens_kv, hidden_size),
+                                device=device, dtype=tensor.dtype)
+    output_tensor = orchestrate_simulate(tensor, output_tensor, fwd_k_metadata)
+    # reverse
+    rev_tensor = torch.zeros((world_size, total_seq_len * max_cp_degree, hidden_size), device=device)
+    rev_tensor = orchestrate_simulate(output_tensor, rev_tensor, rev_k_metadata)
+    rev_tensor = rev_tensor.reshape(world_size, max_cp_degree, total_seq_len, hidden_size)
+
+    rev_tensor_mask = rev_tensor != 0
+    rev_tensor_dedup = rev_tensor.sum(dim=1) / rev_tensor_mask.int().sum(dim=1)
+
+    torch.testing.assert_close(rev_tensor_mask * tensor.unsqueeze(1), rev_tensor)
+    torch.testing.assert_close(tensor, rev_tensor_dedup)
+    rich.print("🟢 Test qkv dispatch passed")
+
+
+def get_sequence_plans_fixed():
+    world_size = 8
+    token_per_rank = 64
+    sequence_plans: List[List[ShardInfo]] = [
+    [
+        ShardInfo(rid=4, dispatch_rid=4, logical_sid=0, shard_len=16),
+        ShardInfo(rid=5, dispatch_rid=5, logical_sid=1, shard_len=16),
+        ShardInfo(rid=6, dispatch_rid=6, logical_sid=2, shard_len=16),
+        ShardInfo(rid=7, dispatch_rid=7, logical_sid=3, shard_len=16),
+        ShardInfo(rid=7, dispatch_rid=7, logical_sid=4, shard_len=16),
+        ShardInfo(rid=6, dispatch_rid=6, logical_sid=5, shard_len=16),
+        ShardInfo(rid=5, dispatch_rid=5, logical_sid=6, shard_len=16),
+        ShardInfo(rid=4, dispatch_rid=4, logical_sid=7, shard_len=16)
+    ],
+    [
+        ShardInfo(rid=4, dispatch_rid=4, logical_sid=0, shard_len=16),
+        ShardInfo(rid=5, dispatch_rid=5, logical_sid=1, shard_len=16),
+        ShardInfo(rid=6, dispatch_rid=6, logical_sid=2, shard_len=16),
+        ShardInfo(rid=7, dispatch_rid=7, logical_sid=3, shard_len=16),
+        ShardInfo(rid=7, dispatch_rid=7, logical_sid=4, shard_len=16),
+        ShardInfo(rid=6, dispatch_rid=6, logical_sid=5, shard_len=16),
+        ShardInfo(rid=5, dispatch_rid=5, logical_sid=6, shard_len=16),
+        ShardInfo(rid=4, dispatch_rid=4, logical_sid=7, shard_len=16)
+    ],
+    [
+        ShardInfo(rid=0, dispatch_rid=0, logical_sid=0, shard_len=32),
+        ShardInfo(rid=1, dispatch_rid=1, logical_sid=1, shard_len=32),
+        ShardInfo(rid=1, dispatch_rid=1, logical_sid=2, shard_len=32),
+        ShardInfo(rid=0, dispatch_rid=0, logical_sid=3, shard_len=32)
+    ],
+    [
+        ShardInfo(rid=2, dispatch_rid=2, logical_sid=0, shard_len=32),
+        ShardInfo(rid=3, dispatch_rid=3, logical_sid=1, shard_len=32),
+        ShardInfo(rid=3, dispatch_rid=3, logical_sid=2, shard_len=32),
+        ShardInfo(rid=2, dispatch_rid=2, logical_sid=3, shard_len=32)
+    ]
+    ]
+    return sequence_plans
+
+
+def test_plan_to_metadata(args):
+    world_size = args.world_size
+    num_seqs = args.num_seqs
+    total_seq_len = args.num_tokens
+    sequence_plans = get_sequence_plans(world_size, num_seqs, total_seq_len)
+    #sequence_plans = get_sequence_plans_fixed()
+    print(sequence_plans)
+    result = plan_to_metadata(args.world_size, sequence_plans)
+
+    return result, sequence_plans
+
+# Generate Random plans for testing.
+def get_sequence_plans(
+    world_size: int,
+    num_seqs: int,
+    total_len: int
+) -> List[List[ShardInfo]]:
+    all_shards = []
+    for rid in range(world_size):
+        num_shards_on_rank = random.randint(2, world_size * 2)
+        ratios = torch.rand(num_shards_on_rank) + 0.1
+        ratios /= ratios.sum()
+        shard_lens_on_rank = (ratios * total_len).round().int()
+        error = shard_lens_on_rank.sum() - total_len
+        shard_lens_on_rank[-1] -= error
+        for shard_len_tensor in shard_lens_on_rank:
+            shard_len = int(shard_len_tensor.item())
+            if shard_len <= 0:
+                continue
+            shard = ShardInfo(
+                rid=rid,
+                dispatch_rid=-1,
+                logical_sid=-1,
+                shard_len=shard_len
+            )
+            all_shards.append(shard)
+    if len(all_shards) < num_seqs:
+        raise ValueError(
+            f"Total number of generated shards ({len(all_shards)}) is not enough to assign to each sequence ({num_seqs})."
+            "Consider increasing world_size or adjusting the number of shards generated per rank."
+        )
+    random.shuffle(all_shards)
+    shards_by_sequence = [[] for _ in range(num_seqs)]
+    for i, shard in enumerate(all_shards):
+        assigned_sid = i % num_seqs
+        shard.dispatch_rid = random.randint(0, world_size - 1)
+        shards_by_sequence[assigned_sid].append(shard)
+    for seq_id in range(num_seqs):
+        current_seq_shards = shards_by_sequence[seq_id]
+        current_seq_shards.sort(key=lambda s: s.rid)
+        for logical_id, shard in enumerate(current_seq_shards):
+            shard.logical_sid = logical_id
+    return shards_by_sequence
+
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description="Test metadata generation")
+    parser.add_argument('--world_size', type=int, default=8)
+    parser.add_argument('--num_seqs', type=int, default=4, help='Number of sequences per rank')
+    parser.add_argument('--max_seq_shard', type=int, default=8, help='Number of shards per sequence')
+    parser.add_argument('--num_tokens', type=int, default=64, help='Total number of tokens per rank')
+    parser.add_argument('--hidden_size', type=int, default=128, help='Hidden size of the tensor')
+    parser.add_argument('--seed', type=int, default=0, help='Random seed for reproducibility')
+    args = parser.parse_args()
+    rich.print(f"Testing {__file__} with args =", args)
+
+    world_size = args.world_size
+    total_seq_len = args.num_tokens
+    num_seqs = args.num_seqs
+
+    test_query_dispatch(args)
+    test_qkv_dispatch(args)


### PR DESCRIPTION
1. Identify Shard_info as output format for planner in the future.
2. handle_planner_metadata: compute intermediate metadata using planner output.
* This function perform right when I check the output meaning and shape.
* Input: world_size, List[List[Shard_info]]. This layout has no constrain.
* Output: Intermediate metadata. Input of compute_e2e_metadata.
4. plan_to_metadata: 
* Input sequence_plans
* Output alltoall metadata.
5. Add test use constant sequence_plan to test.
* Encountered error:[Bypassed this by squeeze]
Seems output (`q_seq_to_dst`) from `compute_metadata` has wrong shape? Need to confirm.

Move ShardInfo into d2.runtime.

Add tests of Plan to Metadata. Pass QKV_dispatch test.

Test Result:
```
Testing /home/pangbo/d2/tests/test_comm_shard_info.py with args = Namespace(world_size=4, num_seqs=4, max_seq_shard=4, num_tokens=64, hidden_size=128, seed=0)
(8, [[ShardInfo(rid=4, dispatch_rid=4, logical_sid=0, shard_len=16), ShardInfo(rid=5, dispatch_rid=5, logical_sid=1, shard_len=16), ShardInfo(rid=6, dispatch_rid=6, logical_sid=2, shard_len=16), ShardInfo(rid=7, dispatch_rid=7, logical_sid=3, shard_len=16), ShardInfo(rid=7, dispatch_rid=7, logical_sid=4, shard_len=16), ShardInfo(rid=6, dispatch_rid=6, logical_sid=5, shard_len=16), ShardInfo(rid=5, dispatch_rid=5, logical_sid=6, shard_len=16), ShardInfo(rid=4, dispatch_rid=4, logical_sid=7, shard_len=16)], [ShardInfo(rid=4, dispatch_rid=4, logical_sid=0, shard_len=16), ShardInfo(rid=5, dispatch_rid=5, logical_sid=1, shard_len=16), ShardInfo(rid=6, dispatch_rid=6, logical_sid=2, shard_len=16), ShardInfo(rid=7, dispatch_rid=7, logical_sid=3, shard_len=16), ShardInfo(rid=7, dispatch_rid=7, logical_sid=4, shard_len=16), ShardInfo(rid=6, dispatch_rid=6, logical_sid=5, shard_len=16), ShardInfo(rid=5, dispatch_rid=5, logical_sid=6, shard_len=16), ShardInfo(rid=4, dispatch_rid=4, logical_sid=7, shard_len=16)], [ShardInfo(rid=0, dispatch_rid=0, logical_sid=0, shard_len=32), ShardInfo(rid=1, dispatch_rid=1, logical_sid=1, shard_len=32), ShardInfo(rid=1, dispatch_rid=1, logical_sid=2, shard_len=32), ShardInfo(rid=0, dispatch_rid=0, logical_sid=3, shard_len=32)], [ShardInfo(rid=2, dispatch_rid=2, logical_sid=0, shard_len=32), ShardInfo(rid=3, dispatch_rid=3, logical_sid=1, shard_len=32), ShardInfo(rid=3, dispatch_rid=3, logical_sid=2, shard_len=32), ShardInfo(rid=2, dispatch_rid=2, logical_sid=3, shard_len=32)]])
🟢 Testing query dispatch
🟢 Test query dispatch passed
⚪ Testing qkv dispatch
[[ShardInfo(rid=0, dispatch_rid=2, logical_sid=0, shard_len=23), ShardInfo(rid=1, dispatch_rid=1, logical_sid=1, shard_len=23), ShardInfo(rid=2, dispatch_rid=1, logical_sid=2, shard_len=13), ShardInfo(rid=3, dispatch_rid=0, logical_sid=3, shard_len=15)], [ShardInfo(rid=0, dispatch_rid=1, logical_sid=0, shard_len=34), ShardInfo(rid=1, dispatch_rid=1, logical_sid=1, shard_len=41), ShardInfo(rid=3, dispatch_rid=1, logical_sid=2, shard_len=10), ShardInfo(rid=3, dispatch_rid=3, logical_sid=3, shard_len=6)], [ShardInfo(rid=0, dispatch_rid=0, logical_sid=0, shard_len=7), ShardInfo(rid=2, dispatch_rid=3, logical_sid=1, shard_len=16), ShardInfo(rid=3, dispatch_rid=1, logical_sid=2, shard_len=13), ShardInfo(rid=3, dispatch_rid=3, logical_sid=3, shard_len=3)], [ShardInfo(rid=2, dispatch_rid=2, logical_sid=0, shard_len=13), ShardInfo(rid=2, dispatch_rid=0, logical_sid=1, shard_len=22), ShardInfo(rid=3, dispatch_rid=3, logical_sid=2, shard_len=9), ShardInfo(rid=3, dispatch_rid=3, logical_sid=3, shard_len=8)]]
🟢 Test qkv dispatch passed

Testing /home/pangbo/d2/tests/test_comm_shard_info.py with args = Namespace(world_size=8, num_seqs=4, max_seq_shard=8, num_tokens=64, hidden_size=128, seed=0)
🟢 Testing query dispatch
🟢 Test query dispatch passed
⚪ Testing qkv dispatch
[[ShardInfo(rid=0, dispatch_rid=1, logical_sid=0, shard_len=6), ShardInfo(rid=2, dispatch_rid=4, logical_sid=1, shard_len=4), ShardInfo(rid=2, dispatch_rid=6, logical_sid=2, shard_len=5), ShardInfo(rid=2, dispatch_rid=4, logical_sid=3, shard_len=10), ShardInfo(rid=3, dispatch_rid=3, logical_sid=4, shard_len=4), ShardInfo(rid=3, dispatch_rid=6, logical_sid=5, shard_len=6), ShardInfo(rid=3, dispatch_rid=2, logical_sid=6, shard_len=16), ShardInfo(rid=4, dispatch_rid=1, logical_sid=7, shard_len=6), ShardInfo(rid=4, dispatch_rid=4, logical_sid=8, shard_len=17), ShardInfo(rid=4, dispatch_rid=5, logical_sid=9, shard_len=21), ShardInfo(rid=5, dispatch_rid=4, logical_sid=10, shard_len=7), ShardInfo(rid=6, dispatch_rid=4, logical_sid=11, shard_len=8), ShardInfo(rid=7, dispatch_rid=4, logical_sid=12, shard_len=4), ShardInfo(rid=7, dispatch_rid=7, logical_sid=13, shard_len=11), ShardInfo(rid=7, dispatch_rid=6, logical_sid=14, shard_len=3), ShardInfo(rid=7, dispatch_rid=7, logical_sid=15, shard_len=10), ShardInfo(rid=7, dispatch_rid=1, logical_sid=16, shard_len=10)], [ShardInfo(rid=0, dispatch_rid=7, logical_sid=0, shard_len=8), ShardInfo(rid=0, dispatch_rid=5, logical_sid=1, shard_len=3), ShardInfo(rid=0, dispatch_rid=4, logical_sid=2, shard_len=3), ShardInfo(rid=1, dispatch_rid=0, logical_sid=3, shard_len=7), ShardInfo(rid=1, dispatch_rid=7, logical_sid=4, shard_len=10), ShardInfo(rid=1, dispatch_rid=6, logical_sid=5, shard_len=10), ShardInfo(rid=1, dispatch_rid=3, logical_sid=6, shard_len=5), ShardInfo(rid=2, dispatch_rid=2, logical_sid=7, shard_len=6), ShardInfo(rid=2, dispatch_rid=0, logical_sid=8, shard_len=8), ShardInfo(rid=2, dispatch_rid=0, logical_sid=9, shard_len=2), ShardInfo(rid=3, dispatch_rid=3, logical_sid=10, shard_len=2), ShardInfo(rid=5, dispatch_rid=1, logical_sid=11, shard_len=4), ShardInfo(rid=6, dispatch_rid=3, logical_sid=12, shard_len=5), ShardInfo(rid=6, dispatch_rid=5, logical_sid=13, shard_len=7), ShardInfo(rid=7, dispatch_rid=3, logical_sid=14, shard_len=9), ShardInfo(rid=7, dispatch_rid=7, logical_sid=15, shard_len=4), ShardInfo(rid=7, dispatch_rid=5, logical_sid=16, shard_len=7)], [ShardInfo(rid=0, dispatch_rid=7, logical_sid=0, shard_len=14), ShardInfo(rid=1, dispatch_rid=2, logical_sid=1, shard_len=2), ShardInfo(rid=1, dispatch_rid=1, logical_sid=2, shard_len=13), ShardInfo(rid=1, dispatch_rid=0, logical_sid=3, shard_len=8), ShardInfo(rid=2, dispatch_rid=6, logical_sid=4, shard_len=5), ShardInfo(rid=2, dispatch_rid=7, logical_sid=5, shard_len=8), ShardInfo(rid=3, dispatch_rid=7, logical_sid=6, shard_len=4), ShardInfo(rid=3, dispatch_rid=0, logical_sid=7, shard_len=7), ShardInfo(rid=3, dispatch_rid=6, logical_sid=8, shard_len=15), ShardInfo(rid=3, dispatch_rid=1, logical_sid=9, shard_len=6), ShardInfo(rid=4, dispatch_rid=1, logical_sid=10, shard_len=3), ShardInfo(rid=5, dispatch_rid=0, logical_sid=11, shard_len=22), ShardInfo(rid=6, dispatch_rid=7, logical_sid=12, shard_len=7), ShardInfo(rid=6, dispatch_rid=6, logical_sid=13, shard_len=3), ShardInfo(rid=6, dispatch_rid=3, logical_sid=14, shard_len=7), ShardInfo(rid=6, dispatch_rid=0, logical_sid=15, shard_len=4)], [ShardInfo(rid=0, dispatch_rid=0, logical_sid=0, shard_len=12), ShardInfo(rid=0, dispatch_rid=1, logical_sid=1, shard_len=10), ShardInfo(rid=0, dispatch_rid=7, logical_sid=2, shard_len=8), ShardInfo(rid=1, dispatch_rid=5, logical_sid=3, shard_len=9), ShardInfo(rid=2, dispatch_rid=7, logical_sid=4, shard_len=7), ShardInfo(rid=2, dispatch_rid=3, logical_sid=5, shard_len=9), ShardInfo(rid=3, dispatch_rid=4, logical_sid=6, shard_len=4), ShardInfo(rid=4, dispatch_rid=5, logical_sid=7, shard_len=17), ShardInfo(rid=5, dispatch_rid=2, logical_sid=8, shard_len=20), ShardInfo(rid=5, dispatch_rid=3, logical_sid=9, shard_len=11), ShardInfo(rid=6, dispatch_rid=5, logical_sid=10, shard_len=2), ShardInfo(rid=6, dispatch_rid=2, logical_sid=11, shard_len=5), ShardInfo(rid=6, dispatch_rid=3, logical_sid=12, shard_len=6), ShardInfo(rid=6, dispatch_rid=3, logical_sid=13, shard_len=3), ShardInfo(rid=6, dispatch_rid=7, logical_sid=14, shard_len=7), ShardInfo(rid=7, dispatch_rid=4, logical_sid=15, shard_len=6)]]
🟢 Test qkv dispatch passed
```