### PR TITLE
Fix number of sequence trimming inplace metadata (?)

### DIFF
--- a/d2/runtime/inplace_metadata.py
+++ b/d2/runtime/inplace_metadata.py
@@ -323,7 +323,7 @@ def compute_attn_layout_seqlens(
     out_seqlens_q = out_seqlens_q.reshape(world_size, max_num_seq)
     out_seqlens_kv = out_seqlens_kv.reshape(world_size, max_num_seq)
 
-    num_local_seqs_recv = local_indices_flat.reshape(-1, world_size).max(dim=0)[0] + 1
+    num_local_seqs_recv = local_indices_flat.reshape(-1, world_size).max(dim=1)[0] + 1
 
     cu_seqlens_q = out_seqlens_q.cumsum(dim=1)
     cu_seqlens_kv = out_seqlens_kv.cumsum(dim=1)


### PR DESCRIPTION
**Changes**

This cause us to calculate less sequences in attention calculation, if the number of sequence in each batch does not stay the same.

```diff
num_local_seqs_recv = local_indices_flat.reshape(-1, world_size).max(dim=0)[0] + 1
-                                                                    ^^^^^
num_local_seqs_recv = local_indices_flat.reshape(-1, world_size).max(dim=1)[0] + 1
+                                                                    ^^^^^
```

**Questions / todo before fix**
1. Is the shape `(-1, world_size)` or `(world_size, -1)`?
2. Test the metadata test with uneven batch lengths