### PR TITLE
[WIP] Fix rope

### DIFF
--- a/d2/runtime/megatron_patch/base_transformer_layer.py
+++ b/d2/runtime/megatron_patch/base_transformer_layer.py
@@ -256,8 +256,6 @@ class TransformerLayer(MegatronTransformerLayer):
         assert context_mask is None, "cross-attention not supported yet"
 
         setattr(packed_seq_params, "stream", torch.cuda.current_stream())
-        # FIXME(yonghao): fix rope
-        rotary_pos_emb = None
 
         query, key, value, residual, attn_mask_type = self._forward_pre_core_attn(
             hidden_states,

--- a/d2/runtime/megatron_patch/transformer_layer.py
+++ b/d2/runtime/megatron_patch/transformer_layer.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager, nullcontext
 import functools
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 import types
 import warnings
 import time
@@ -549,7 +549,6 @@ def add_ping_pang_forward(block: MegatronTransformerBlock):
             hidden_states = self.input_tensor
 
         hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
-        rotary_pos_emb = None
 
         if self.config.sequence_parallel:
             rng_context = tensor_parallel.get_cuda_rng_tracker().fork()


### PR DESCRIPTION
This PR fixes rope.

The previous error  is caused by unexpectedly splitting `rotary_pos_emb` when preparing ping-pong arguments.

CLARIFY before merge: the current sequence length of `rotary_pos_emb` is `max_seq_len_{q,kv} * cp_size`. Is this enough in our case?