### PR TITLE
[FIX] sync after signal buffer is initialized and before it's putmem

### DIFF
--- a/d2/runtime/attn_kernels/ops.py
+++ b/d2/runtime/attn_kernels/ops.py
@@ -76,6 +76,8 @@ class FastDispatcherWrapper:
         )
         # the buffer_released is initialized by all zeros. We should
         # manually release them here once.
+        torch.cuda.synchronize()
+        torch.distributed.barrier()
         _ops.release_buffer(self.handle)
         self.release_event = torch.cuda.Event()
         self.release_event.record(torch.cuda.current_stream())


### PR DESCRIPTION
previous logic:

nvshmem_alloc(signal)
memset(signal, 0)
nvshmem_put_signal(signal)

In some very rare cases, nvshmem_put_signal to a remote is faster than the memset on the remote. This PR fixes this issue by inserting a synchronization after the memset, before the nvshmem_put_signal