### PR TITLE
Make Traceback util cleaner

### DIFF
--- a/d2/utils/traceback.py
+++ b/d2/utils/traceback.py
@@ -35,53 +35,59 @@ def enable_clickable_excepthook():
     print("🟡 Enabling clickable excepthook.")
     sys.excepthook = clickable_excepthook
 
+import sys
 
-def trace_calls(frame, event, arg):
-    if event == "call":
-        code = frame.f_code
-        print(f"--> Enter {code.co_name} ({code.co_filename}:{frame.f_lineno})")
-    elif event == "return":
-        code = frame.f_code
-        print(f"<-- Exit {code.co_name} ({code.co_filename}:{frame.f_lineno})")
-    return trace_calls
-
-
+BLUE = "\033[34m"
+RESET = "\033[0m"
 
 class TraceFunctions:
-    def __init__(self, filter_path=None):
+    def __init__(self, filter_path: str = None):
         self.filter_path = filter_path
         self._oldtrace = None
         self.indent = 0
 
     def _trace(self, frame, event, arg):
-        if event in ("call", "return"):
-            code = frame.f_code
-            filename = code.co_filename
-            if self.filter_path and self.filter_path not in filename:
-                return
-            if event == "call":
-                print(f"{BLUE}{' ' * self.indent}--> Enter {code.co_name} ({filename}:{frame.f_lineno}){RESET}")
-                self.indent += 1
-            elif event == "return":
-                print(f"{BLUE}{' ' * self.indent}<-- Exit  {code.co_name} ({filename}:{frame.f_lineno}){RESET}")
-                self.indent -= 1
+        if event not in ("call", "return"):
+            return self._trace
+
+        code = frame.f_code
+        filename = code.co_filename
+        funcname = code.co_name
+
+        # filter: only trace if substring matches
+        if self.filter_path and self.filter_path not in filename:
+            return self._trace
+
+        if event == "call":
+            print(f"{BLUE}{' ' * self.indent}--> Enter {funcname} ({filename}:{frame.f_lineno}){RESET}")
+            self.indent += 1
+        elif event == "return":
+            self.indent = max(0, self.indent - 1)
+            print(f"{BLUE}{' ' * self.indent}<-- Exit  {funcname} ({filename}:{frame.f_lineno}){RESET}")
+
         return self._trace
 
     def __enter__(self):
         self._oldtrace = sys.gettrace()
-        if not should_trace_calls:
-            return self
         sys.settrace(self._trace)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         sys.settrace(self._oldtrace)
 
-def enable_trace_calls():
-    print("🟡 Enabling python debug trace calls.")
-    sys.settrace(trace_calls)
 
+def enable_trace_calls(filter_path: str = None) -> TraceFunctions:
+    """
+    Enable tracing immediately.
+    Returns the TraceFunctions instance in case you want to disable later.
+    """
+    tracer = TraceFunctions(filter_path)
+    sys.settrace(tracer._trace)
+    return tracer
 
+# Example usage:
+# with TraceFunctions(filter_path="my_project"):
+#     run_my_code()
 # if should_enable_clickable_excepthook:
 #     enable_clickable_excepthook()
 # if should_trace_calls:


### PR DESCRIPTION
**Usage**

```python
with TraceFunctions("d2/runtime"): # <-- only output stuff within d2 runtime folder
  loss, grad = worker.forward_backward_batch(...)

```