### PR TITLE
Remove hard code env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ slurm/
 env.sh
 logs/
 # playground/
+logs-latest

--- a/playground/test_megatron_init.sh
+++ b/playground/test_megatron_init.sh
@@ -12,12 +12,71 @@
 #SBATCH --time=01:00:00
 
 
-NNODES=1
-NPROC_PER_NODE=1
-JOBID=1390200
-HEAD_NODE_IP=fs-mbz-gpu-044
+TP=1
+PP=1
+CP=1
+DP=1
+NUM_GPUS=$((TP * PP * CP * DP))
+NPROC_PER_NODE=$((NUM_GPUS < 8 ? NUM_GPUS : 8))
+NNODES=$((NUM_GPUS / NPROC_PER_NODE))
+echo TP=$TP, PP=$PP, CP=$CP, DP=$DP, NUM_GPUS=$NUM_GPUS, NPROC_PER_NODE=$NPROC_PER_NODE, NNODES=$NNODES
+
 
 source .env.sh
+
+# ================================
+# Setup SLURM environment variables
+# - JOBID: SLURM job ID
+# - HEAD_NODE_IP: IP of head node
+# ================================
+if [ -n "$SLURM_JOB_ID" ] || [ -n "$SLURM_NODELIST" ] || [ -n "$SLURM_NNODES" ]; then
+    is_in_slurm_env=1
+else
+    is_in_slurm_env=0
+fi
+
+if [ "$is_in_slurm_env" -eq 1 ]; then
+    # Use SLURM variables when present
+    JOBID=$SLURM_JOB_ID
+    # Set HEAD_NODE_IP from SLURM_NODELIST if not already set
+    echo SLURM_NODELIST=$SLURM_NODELIST
+    SCONTROL_NODES=$(scontrol show hostnames "$SLURM_NODELIST")
+    HEAD_NODE_IP=$(echo "$SCONTROL_NODES" | head -n 1)
+    export JOBID
+    export HEAD_NODE_IP
+else
+    # Not in SLURM: rely on whatever was set in .env.sh or environment
+    JOBID="${JOBID}"
+    
+    # If JOBID is provided, query SLURM to get the node list
+    if [ -n "$JOBID" ]; then
+        echo "Querying SLURM for job $JOBID node list..."
+        # Get the node list from scontrol show job
+        NODELIST=$(scontrol show job "$JOBID" | grep -oP '^[\s]+NodeList=\K[^\s]+' || echo "")
+        
+        if [ -n "$NODELIST" ]; then
+            echo "Found node list: $NODELIST"
+            # Convert node list to hostnames and get the first one
+            SCONTROL_NODES=$(scontrol show hostnames "$NODELIST")
+            HEAD_NODE_IP=$(echo "$SCONTROL_NODES" | head -n 1)
+            echo "Using head node: $HEAD_NODE_IP"
+        else
+            echo "Warning: Could not retrieve node list for job $JOBID"
+            exit 1
+        fi
+    else
+        HEAD_NODE_IP="${HEAD_NODE_IP}"
+    fi
+fi
+
+echo JOBID=$JOBID
+echo HEAD_NODE_IP=$HEAD_NODE_IP
+
+
+
+# =====================================
+# NCCL debug flags for troubleshooting
+# =====================================
 
 # NCCL debug flags for troubleshooting
 # export NCCL_DEBUG=INFO
@@ -42,10 +101,13 @@ mkdir -p "$TORCH_EXTENSIONS_DIR" "$TRITON_CACHE_DIR"
 export PYTHONPYCACHEPREFIX=/tmp/$USER/pycache
 mkdir -p "$PYTHONPYCACHEPREFIX"
 
-# --------------------------------
+# ==============================================================
 # Logging directory setup
-# Generate timestamp once and share between nsys and Python
-# --------------------------------
+# - DISTCA_LOG_TIMESTAMP: Timestamp of the log
+# - DISTCA_LOG_BASE_DIR: Base directory of the logs
+# - DISTCA_LOG_ROOT_DIR: Root directory of the logs
+# - DISTCA_LOG_LATEST_LINK: Link to the latest log directory
+# ==============================================================
 CURDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export DISTCA_LOG_TIMESTAMP=$(TZ=America/Los_Angeles date +%Y%m%d_%H%M%S)
 export DISTCA_LOG_BASE_DIR="${CURDIR}/logs"
@@ -63,9 +125,15 @@ mkdir -p "${DISTCA_LOG_ROOT_DIR}/data_cache"
 ln -sfn "${DISTCA_LOG_ROOT_DIR}" "${DISTCA_LOG_LATEST_LINK}"
 
 set -x
-# nsys profile --trace=cuda,nvtx --force-overwrite=true -o "${DISTCA_LOG_ROOT_DIR}/nsys/nsys-rep.%h.nsys-rep" --sample=none --capture-range=cudaProfilerApi --capture-range-end=stop \
+
+# ==============================================================
+# Run the test using SLURM
+# ==============================================================
+
+
 
 srun -w ${HEAD_NODE_IP} -N ${NNODES} --gres=gpu:${NPROC_PER_NODE} --jobid=${JOBID} \
+nsys profile --trace=cuda,nvtx --force-overwrite=true -o "${DISTCA_LOG_ROOT_DIR}/nsys/nsys-rep.%h.nsys-rep" --sample=none --capture-range=cudaProfilerApi --capture-range-end=stop \
 torchrun --nnodes=${NNODES} --nproc_per_node=${NPROC_PER_NODE} --rdzv_backend=c10d --rdzv_endpoint=${HEAD_NODE_IP}:29800 --rdzv_id=0000 --max_restarts=0 \
     test_megatron_init.py 
 

--- a/tests/test_nvshmem_init.sh
+++ b/tests/test_nvshmem_init.sh
@@ -13,12 +13,12 @@
 export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1 
 export NVSHMEM_IB_ENABLE_IBGDA=true
 
-export CUDA_DIR=/mnt/sharefs/software/DeepEP/cuda-12-6
-export NCCL_HOME=/usr
-export NCCL_LIB=/usr/lib/x86_64-linux-gnu
-export NVSHMEM_DIR=/mnt/weka/home/yonghao.zhuang/opt/nvshmem
-export NVSHMEM_PREFIX=/mnt/weka/home/yonghao.zhuang/opt/nvshmem
-export OPENMPI_DIR=/mnt/weka/home/yonghao.zhuang/opt/openmpi
+: "${CUDA_DIR:?Must set CUDA_DIR}"
+: "${NCCL_HOME:?Must set NCCL_HOME}"
+: "${NCCL_LIB:?Must set NCCL_LIB}"
+: "${NVSHMEM_DIR:?Must set NVSHMEM_DIR}"
+: "${NVSHMEM_PREFIX:?Must set NVSHMEM_PREFIX}"
+: "${OPENMPI_DIR:?Must set OPENMPI_DIR}"
 
 export LD_LIBRARY_PATH="${NVSHMEM_DIR}/lib:${CUDA_DIR}/lib64:${OPENMPI_DIR}/lib:${NCCL_LIB}/:$LD_LIBRARY_PATH"
 export PATH="${NVSHMEM_DIR}/bin:${OPENMPI_DIR}/bin:${CUDA_DIR}/bin:$PATH"


### PR DESCRIPTION
**Description**
- Improves the initialization scripts for distributed training and testing environments, 
- Replaced hardcoded export statements for key environment variables (`CUDA_DIR`, `NCCL_HOME`, etc.) with checks that ensure these variables are set before proceeding, making the script more robust and less error-prone in different environments.