### PR TITLE
ci: add Modal GPU smoke test proving distca compiles & runs

### DIFF
--- a/.github/workflows/ci-modal-smoke.yml
+++ b/.github/workflows/ci-modal-smoke.yml
@@ -1,0 +1,57 @@
+name: CI — Modal Smoke Test
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-modal-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  modal-smoke:
+    name: "GPU Smoke Test (Modal H100)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Modal CLI
+        run: pip install modal
+
+      - name: Authenticate Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          # Modal CLI reads MODAL_TOKEN_ID and MODAL_TOKEN_SECRET from env.
+          # Verify the credentials work.
+          modal profile list || true
+          echo "Modal authentication configured via environment variables."
+
+      - name: Run DistCA smoke test on Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: modal run ci/modal_smoke_test.py
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## CI Modal Smoke Test" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "✅ **DistCA compiled and ran successfully on a Modal H100.**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **DistCA smoke test failed.** Check logs above." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,71 @@
+# CI — Modal GPU Smoke Test
+
+This CI workflow proves that DistCA compiles and runs on real GPU hardware by
+executing the full "install + build csrc + single-GPU pretrain" pipeline on a
+Modal H100.
+
+## What it runs
+
+1. **Planner unit tests** — `tests/test_planner.py` and `tests/test_items.py`
+2. **Single-GPU smoke test** — `scripts/docker_install_and_build.sh --smoke`
+   (installs distca, builds csrc/libas_comm, runs 1-batch pretrain_llama.py)
+
+## Setup — GitHub Secrets
+
+You need **two** repository secrets so the GitHub Actions runner can talk to
+your Modal account.
+
+### 1. Create a Modal API token
+
+```bash
+# Install Modal locally (if you haven't)
+pip install modal
+
+# Create a token — this opens the browser to log in
+modal token new
+```
+
+After logging in, Modal stores the credentials in `~/.modal.toml`. You can
+view them:
+
+```bash
+cat ~/.modal.toml
+```
+
+You'll see two values:
+- `token_id`     → this becomes `MODAL_TOKEN_ID`
+- `token_secret` → this becomes `MODAL_TOKEN_SECRET`
+
+### 2. Add the secrets to GitHub
+
+Go to your repo → **Settings** → **Secrets and variables** → **Actions** →
+**New repository secret**:
+
+| Secret name          | Value                              |
+|---------------------|------------------------------------|
+| `MODAL_TOKEN_ID`     | The `token_id` from `~/.modal.toml`  |
+| `MODAL_TOKEN_SECRET` | The `token_secret` from `~/.modal.toml` |
+
+Or use the CLI:
+
+```bash
+gh secret set MODAL_TOKEN_ID     --body "<your-token-id>"
+gh secret set MODAL_TOKEN_SECRET --body "<your-token-secret>"
+```
+
+### 3. Verify
+
+Push to `main` or open a PR — the **"CI — Modal Smoke Test"** workflow should
+appear in the Actions tab.
+
+## Running locally
+
+```bash
+# From repo root
+modal run ci/modal_smoke_test.py
+```
+
+## Cost
+
+Each run uses ~10-30 minutes of Modal H100 time (\~$0.33/min as of mid-2026).
+The CI uses concurrency groups to cancel stale runs on force-pushes.

--- a/ci/modal_smoke_test.py
+++ b/ci/modal_smoke_test.py
@@ -1,0 +1,153 @@
+"""
+DistCA CI Smoke Test on Modal.
+
+Runs the full install-and-build pipeline followed by the single-GPU smoke test
+on a Modal H100 (or fallback A100). This proves that distca compiles the C++/CUDA
+extensions and completes one end-to-end pretrain_llama.py iteration.
+
+Usage (local):
+    modal run ci/modal_smoke_test.py
+
+Usage (CI):
+    Requires MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables.
+    modal run ci/modal_smoke_test.py
+"""
+
+import modal
+
+# ---------------------------------------------------------------------------
+# Image: NGC PyTorch base with NVSHMEM pip package + build deps
+# ---------------------------------------------------------------------------
+distca_image = (
+    modal.Image.from_registry(
+        "nvcr.io/nvidia/pytorch:24.12-py3",
+        add_python="3.12",
+    )
+    .pip_install("ninja", "cmake", "nvidia-nvshmem-cu12", "rich", "omegaconf")
+    .pip_install("transformers>=4.40,<4.46")
+    # flash-attn is built from source inside the smoke test (slow but correct)
+)
+
+app = modal.App("distca-ci-smoke", image=distca_image)
+
+# Mount the entire repo into the container
+repo_mount = modal.Mount.from_local_dir(".", remote_path="/workspace/DistCA")
+
+# ---------------------------------------------------------------------------
+# Single-GPU smoke test function
+# ---------------------------------------------------------------------------
+@app.function(
+    gpu="H100",
+    timeout=1800,  # 30 min for build + smoke
+    mounts=[repo_mount],
+)
+def smoke_test():
+    """Install distca, build csrc, then run single-GPU smoke test."""
+    import subprocess
+    import os
+    import sys
+
+    os.chdir("/workspace/DistCA")
+    os.environ["DISTCA_ROOT"] = "/workspace/DistCA"
+    # Reduce NVSHMEM buffer for 1-GPU config
+    os.environ["EXPERIMENT_NVSHMEM_BUFFER_SIZE_GB"] = "0.1"
+    # Build for Hopper (H100 = sm_90a)
+    os.environ["CMAKE_CUDA_ARCHITECTURES"] = "90a"
+
+    print("=" * 60)
+    print("  DistCA CI — install + build + single-GPU smoke test")
+    print("=" * 60, flush=True)
+
+    # Step 1: Install & build (docker_install_and_build.sh --smoke runs the
+    # smoke test at the end, so we just call it with --smoke directly)
+    result = subprocess.run(
+        ["bash", "scripts/docker_install_and_build.sh", "--smoke"],
+        env=os.environ | {"PATH": os.environ.get("PATH", "")},
+        cwd="/workspace/DistCA",
+        capture_output=False,
+    )
+
+    if result.returncode != 0:
+        print(f"\n❌ Smoke test FAILED (exit code {result.returncode})")
+        sys.exit(result.returncode)
+
+    print("\n✅ DistCA single-GPU smoke test PASSED on Modal")
+    return "PASSED"
+
+
+# ---------------------------------------------------------------------------
+# Planner unit tests (CPU-only, runs fast)
+# ---------------------------------------------------------------------------
+@app.function(
+    gpu="H100",  # need torch.cuda for some planner tests
+    timeout=600,
+    mounts=[repo_mount],
+)
+def planner_tests():
+    """Run planner unit tests (test_planner.py, test_items.py)."""
+    import subprocess
+    import os
+    import sys
+
+    os.chdir("/workspace/DistCA")
+    os.environ["DISTCA_ROOT"] = "/workspace/DistCA"
+
+    # Install distca (no csrc needed for planner tests)
+    subprocess.run(
+        ["pip", "install", "-e", ".", "--quiet"],
+        cwd="/workspace/DistCA",
+        check=True,
+    )
+    subprocess.run(
+        ["pip", "install", "-r", "requirements.txt", "--quiet"],
+        cwd="/workspace/DistCA",
+        check=True,
+    )
+    subprocess.run(
+        ["pip", "install", "transformers>=4.40,<4.46", "--quiet"],
+        cwd="/workspace/DistCA",
+        check=True,
+    )
+
+    print("=" * 60)
+    print("  DistCA CI — Planner unit tests")
+    print("=" * 60, flush=True)
+
+    failed = False
+    for test_file in ["tests/test_planner.py", "tests/test_items.py"]:
+        print(f"\n--- Running {test_file} ---", flush=True)
+        result = subprocess.run(
+            ["python", test_file],
+            cwd="/workspace/DistCA",
+        )
+        if result.returncode != 0:
+            print(f"❌ {test_file} FAILED")
+            failed = True
+        else:
+            print(f"✅ {test_file} PASSED")
+
+    if failed:
+        sys.exit(1)
+
+    print("\n✅ All planner tests PASSED on Modal")
+    return "PASSED"
+
+
+@app.local_entrypoint()
+def main():
+    """Run all CI checks."""
+    print("🚀 Launching DistCA CI on Modal...\n")
+
+    # Run planner tests first (faster, cheaper)
+    print("📋 Running planner unit tests...")
+    planner_result = planner_tests.remote()
+    print(f"   Planner tests: {planner_result}")
+
+    # Run full single-GPU smoke test
+    print("\n🔥 Running single-GPU smoke test...")
+    smoke_result = smoke_test.remote()
+    print(f"   Smoke test: {smoke_result}")
+
+    print("\n" + "=" * 60)
+    print("  ✅ All DistCA CI checks PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## What

Adds a CI workflow that runs on every push/PR to `main` and proves DistCA compiles and runs on real GPU hardware via [Modal](https://modal.com).

### New files

| File | Purpose |
|------|---------|
| `ci/modal_smoke_test.py` | Modal app: installs distca, builds csrc, runs planner unit tests, then single-GPU smoke test on H100 |
| `.github/workflows/ci-modal-smoke.yml` | GitHub Actions workflow triggered on push/PR to main |
| `ci/README.md` | Setup guide for the two required GitHub secrets |

### Required secrets

| Secret | How to get it |
|--------|--------------|
| `MODAL_TOKEN_ID` | `modal token new` → from `~/.modal.toml` |
| `MODAL_TOKEN_SECRET` | same as above |

### Cost

Each run uses ~10–30 min of Modal H100 time. Concurrency groups cancel stale runs on force-pushes.

### Verification

After adding the secrets, the workflow will appear in the Actions tab. You can also test locally with `modal run ci/modal_smoke_test.py`.